### PR TITLE
Refactor: 네비게이션 드롭다운 메뉴 group-hover 방식으로 리팩토링

### DIFF
--- a/src/components/layout/navigation/full-desktop-menu.tsx
+++ b/src/components/layout/navigation/full-desktop-menu.tsx
@@ -2,9 +2,9 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import { sortSubItems } from "@/utils/navigation-utils";
-import { FullDesktopMenuProps } from "@/types/navigation-props";
+import { FullMenuProps } from "@/types/navigation-props";
 
-const FullDesktopMenu = ({ sortedMenuData, isMenuOpen }: FullDesktopMenuProps) => {
+const FullDesktopMenu = ({ sortedMenuData, isMenuOpen }: FullMenuProps) => {
   return (
     <AnimatePresence>
       {isMenuOpen && (

--- a/src/components/layout/navigation/full-mobile-menu.tsx
+++ b/src/components/layout/navigation/full-mobile-menu.tsx
@@ -9,9 +9,9 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { sortSubItems } from "@/utils/navigation-utils";
-import { FullMobileMenuProps } from "@/types/navigation-props";
+import { FullMenuProps } from "@/types/navigation-props";
 
-const FullMobileMenu = ({ sortedMenuData, isMenuOpen }: FullMobileMenuProps) => {
+const FullMobileMenu = ({ sortedMenuData, isMenuOpen }: FullMenuProps) => {
   const defaultAccordionValue = sortedMenuData[0].id.toString();
 
   return (

--- a/src/components/layout/navigation/hover-dropdown-menu.tsx
+++ b/src/components/layout/navigation/hover-dropdown-menu.tsx
@@ -1,52 +1,54 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
 import { sortSubItems } from "@/utils/navigation-utils";
-import { HoverDropdownMenuProps } from "@/types/navigation-props";
+import { NavigationItem } from "@/types/navigation-data";
 
-const HoverDropdownMenu = ({
-  activeCategory,
-  activeMenuItem,
-  isMenuOpen,
-}: HoverDropdownMenuProps) => {
+const HoverDropdownMenu = ({ menuItem }: { menuItem: NavigationItem }) => {
   return (
-    <AnimatePresence>
-      {activeCategory && !isMenuOpen && activeMenuItem && activeMenuItem.type === "group" && (
-        <motion.div
-          className="absolute top-full left-0 w-full bg-white text-gray-800 shadow-lg lg:block z-40"
-          initial={{ opacity: 0, y: 0 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 0 }}
-          transition={{ duration: 0.3 }}
+    <>
+      {menuItem.type === "group" && (
+        <div
+          className={cn(
+            "absolute top-full left-0 w-full bg-white text-gray-800 shadow-lg z-40",
+            "transition-all duration-300 ease-out",
+            "opacity-0 pointer-events-none",
+            "group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto",
+            "cursor-default",
+          )}
         >
           <div className="container mx-auto px-4 py-8">
-            <div className="grid grid-cols-4 gap-8">
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3 }}
-              >
-                <h3 className="font-bold text-figma-alizarin-crimson mb-4 text-lg">
-                  {activeMenuItem.slug}
-                </h3>
-                <ul className="space-y-2">
-                  {sortSubItems(activeMenuItem.items).map((subItem) => (
-                    <li key={subItem.id}>
-                      <a
-                        href={subItem.link}
-                        className="text-gray-600 hover:text-figma-alizarin-crimson transition-colors duration-200 block py-1"
-                      >
-                        {subItem.slug}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </motion.div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-8">
+              <div className="space-y-4">
+                <h2 className="text-xl font-bold border-b border-gray-200 pb-2">
+                  <Link
+                    href={menuItem.link}
+                    className="text-figma-alizarin-crimson hover:text-figma-alizarin-crimson/80 transition-colors duration-200"
+                  >
+                    {menuItem.slug}
+                  </Link>
+                </h2>
+                <div>
+                  <ul className="space-y-2">
+                    {sortSubItems(menuItem.items).map((item) => (
+                      <li key={item.id}>
+                        <Link
+                          href={item.link}
+                          className="text-gray-600 hover:text-figma-alizarin-crimson transition-colors duration-200 block my-4 text-sm border-l-2 border-transparent hover:border-figma-alizarin-crimson pl-3"
+                        >
+                          {item.slug}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
-        </motion.div>
+        </div>
       )}
-    </AnimatePresence>
+    </>
   );
 };
 

--- a/src/components/layout/navigation/navigation-bar.tsx
+++ b/src/components/layout/navigation/navigation-bar.tsx
@@ -1,42 +1,39 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
+import HoverDropdownMenu from "./hover-dropdown-menu";
+import { cn } from "@/lib/utils";
 import { sortMenuData } from "@/utils/navigation-utils";
-import { DesktopNavigationProps } from "@/types/navigation-props";
+import { NavigationProps } from "@/types/navigation-props";
+import { NavigationItem } from "@/types/navigation-data";
 
-const NavigationBar = ({
-  menuData,
-  activeCategory,
-  onCategoryHover,
-  onNavMouseEnter,
-  onNavMouseLeave,
-}: DesktopNavigationProps) => {
+const NavigationBar = ({ menuData }: NavigationProps) => {
+  const router = useRouter();
   const sortedMenuData = sortMenuData(menuData);
 
+  const handleMove = (item: NavigationItem) => {
+    if (item.type === "single") router.push(item.link);
+  };
+
   return (
-    <div onMouseEnter={onNavMouseEnter} onMouseLeave={onNavMouseLeave}>
-      <nav className="hidden lg:flex items-center">
+    <nav>
+      <ul className="hidden lg:flex items-center">
         {sortedMenuData.map((item) => (
-          <motion.a
+          <motion.li
             key={item.id}
-            href={item.link}
-            className={`duration-200 font-medium px-4 py-5 relative after:absolute after:left-2 after:bottom-3 after:h-[2px] after:w-0 hover:after:w-[calc(100%-1rem)] after:bg-white after:transition-all after:duration-300 ${
-              activeCategory === item.slug ? "after:w-[calc(100%-1rem)]" : ""
-            }`}
-            onMouseEnter={() => {
-              if (item.type === "group") {
-                onCategoryHover(item.slug);
-              } else {
-                onCategoryHover(null);
-              }
-            }}
-            onClick={item.type === "single" ? undefined : (e) => e.preventDefault()}
+            className={cn("group", "px-4 py-5", "duration-200 font-medium cursor-pointer")}
+            onClick={() => handleMove(item)}
           >
-            {item.slug}
-          </motion.a>
+            <h3 className="text-white group-hover:text-white transition-colors duration-300">
+              {item.slug}
+            </h3>
+            <div className="h-[2px] w-0 bg-white group-hover:w-full transition-all duration-300 relative top-[5px]"></div>
+            <HoverDropdownMenu menuItem={item} />
+          </motion.li>
         ))}
-      </nav>
-    </div>
+      </ul>
+    </nav>
   );
 };
 

--- a/src/components/layout/navigation/navigation-container.tsx
+++ b/src/components/layout/navigation/navigation-container.tsx
@@ -1,28 +1,13 @@
 "use client";
 
-import {
-  NavigationBar,
-  FullDesktopMenu,
-  FullMobileMenu,
-  HoverDropdownMenu,
-  HamburgerButton,
-} from "./";
+import { NavigationBar, FullDesktopMenu, FullMobileMenu, HamburgerButton } from "./";
 import { useNavigation } from "@/hooks/use-navigation";
 import { useMobile } from "@/hooks/use-mobile";
-import { findMenuItemBySlug, sortMenuData } from "@/utils/navigation-utils";
+import { sortMenuData } from "@/utils/navigation-utils";
 import { NavigationProps } from "@/types/navigation-props";
 
 const NavigationContainer = ({ menuData }: NavigationProps) => {
-  const {
-    isMenuOpen,
-    activeCategory,
-    toggleMenu,
-    handleCategoryHover,
-    handleNavMouseLeave,
-    handleNavMouseEnter,
-  } = useNavigation();
-
-  const activeMenuItem = findMenuItemBySlug(menuData, activeCategory || "");
+  const { isMenuOpen, toggleMenu } = useNavigation();
 
   const [isMobile, _] = useMobile({ breakpoint: 768 });
 
@@ -30,22 +15,10 @@ const NavigationContainer = ({ menuData }: NavigationProps) => {
 
   return (
     <>
-      <div className="flex items-center justify-between w-full">
-        <NavigationBar
-          menuData={menuData}
-          activeCategory={activeCategory}
-          onCategoryHover={handleCategoryHover}
-          onNavMouseEnter={handleNavMouseEnter}
-          onNavMouseLeave={handleNavMouseLeave}
-        />
+      <div className="flex items-center justify-between w-full dropdown-menu">
+        <NavigationBar menuData={menuData} />
         <HamburgerButton isMenuOpen={isMenuOpen} onToggle={toggleMenu} />
       </div>
-
-      <HoverDropdownMenu
-        activeCategory={activeCategory}
-        activeMenuItem={activeMenuItem}
-        isMenuOpen={isMenuOpen}
-      />
 
       {isMobile ? (
         <FullMobileMenu sortedMenuData={sortedMenuData} isMenuOpen={isMenuOpen} />

--- a/src/hooks/use-navigation.ts
+++ b/src/hooks/use-navigation.ts
@@ -1,61 +1,19 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 
 interface UseNavigationReturn {
   isMenuOpen: boolean;
-  activeCategory: string | null;
   toggleMenu: () => void;
-  setActiveCategory: (category: string | null) => void;
-  handleCategoryHover: (category: string | null) => void;
-  handleNavMouseLeave: () => void;
-  handleNavMouseEnter: () => void;
 }
 
 export const useNavigation = (): UseNavigationReturn => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [activeCategory, setActiveCategory] = useState<string | null>(null);
-  const [hoverTimeout, setHoverTimeout] = useState<NodeJS.Timeout | null>(null);
 
   const toggleMenu = useCallback(() => {
     setIsMenuOpen(!isMenuOpen);
-    setActiveCategory(null);
   }, [isMenuOpen]);
-
-  const handleCategoryHover = useCallback(
-    (category: string | null) => {
-      if (hoverTimeout) {
-        clearTimeout(hoverTimeout);
-        setHoverTimeout(null);
-      }
-      setActiveCategory(category);
-    },
-    [hoverTimeout],
-  );
-
-  const handleNavMouseLeave = useCallback(() => {
-    const timeout = setTimeout(() => setActiveCategory(null), 50);
-    setHoverTimeout(timeout);
-  }, []);
-
-  const handleNavMouseEnter = useCallback(() => {
-    if (hoverTimeout) {
-      clearTimeout(hoverTimeout);
-      setHoverTimeout(null);
-    }
-  }, [hoverTimeout]);
-
-  useEffect(() => {
-    return () => {
-      if (hoverTimeout) clearTimeout(hoverTimeout);
-    };
-  }, [hoverTimeout]);
 
   return {
     isMenuOpen,
-    activeCategory,
     toggleMenu,
-    setActiveCategory,
-    handleCategoryHover,
-    handleNavMouseLeave,
-    handleNavMouseEnter,
   };
 };

--- a/src/types/navigation-props.ts
+++ b/src/types/navigation-props.ts
@@ -4,25 +4,8 @@ export interface NavigationProps {
   menuData: NavigationDataType;
 }
 
-export interface DesktopNavigationProps extends NavigationProps {
-  activeCategory: string | null;
-  onCategoryHover: (category: string | null) => void;
-  onNavMouseEnter: () => void;
-  onNavMouseLeave: () => void;
-}
-
 export interface FullMenuProps {
   sortedMenuData: NavigationDataType;
-  isMenuOpen: boolean;
-}
-
-export interface FullDesktopMenuProps extends FullMenuProps {}
-
-export interface FullMobileMenuProps extends FullMenuProps {}
-
-export interface HoverDropdownMenuProps {
-  activeCategory: string | null;
-  activeMenuItem: any;
   isMenuOpen: boolean;
 }
 


### PR DESCRIPTION
## 작업 내용
- 기존에는 드롭 다운 메뉴 열림/닫힘을 상태(state)로 관리하며 props로 전달했음
- 이번 커밋에서는 상태 관리를 제거하고 `group-hover` 기반의 CSS 방식으로 리팩토링 함

## 기대 효과
- 불필요한 리렌더링 제거
- 코드 간결화 및 유지보수 용이성 향상
- Hover 시 자연스러운 UX 제공

## 관련 이슈
- #4 